### PR TITLE
On OSX return "Mac OS" in os-dispatch rather than "Windows".

### DIFF
--- a/src/rksm/cloxp_installer/main.clj
+++ b/src/rksm/cloxp_installer/main.clj
@@ -20,10 +20,7 @@
 
 (defn- os-dispatch
   [{os-name :name :or {os-name ""}}]
-  #_(re-find #"Windows|Mac OS" os-name)
-  (if (= (re-find #"Windows|Mac OS" os-name) "Mac OS")
-    "Windows"
-    (re-find #"Windows|Mac OS" os-name)))
+  (re-find #"Windows|Mac OS" os-name))
 
 (def ^:dynamic *release-tag* nil)
 (def cloxp-dir (-> "." io/file .getCanonicalPath))


### PR DESCRIPTION
Fixes the `./install.sh` script under OS X.

Previously `./install.sh` was failing without much feedback because it attempted to invoke `cmd.exe`:

```
/s/cloxp-install git:master ❯❯❯ ./install.sh
installing cloxp pre-0.0.8
1. Checking dependencies...
(error installing cloxp:
 )
```
